### PR TITLE
unleash-server needs node:12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 COPY package.json ./
 


### PR DESCRIPTION
unleash-server needs node:12

```
error unleash-server@3.3.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.20.1
```